### PR TITLE
Závislost na rozšíření OpenSSL

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require": {
         "php": ">=5.6.0",
         "robrichards/wse-php": "2.0.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-openssl": "*"
     }
 }

--- a/src/Certificate.php
+++ b/src/Certificate.php
@@ -25,6 +25,10 @@ class Certificate
         $certs = [];
         $pkcs12 = file_get_contents($certificate);
 
+        if (!extension_loaded('openssl') || !function_exists('openssl_pkcs12_read')) {
+            throw new ClientException("Rozsireni OpenSSL neni dostupne.");
+        }
+
         $openSSL = openssl_pkcs12_read($pkcs12, $certs, $password);
         if(!$openSSL)
         {


### PR DESCRIPTION
Pro čtení certifikátu je třeba PHP rozšíření OpenSSL, které nemusí být dostupné na všech instalacích PHP. Je tedy dobré mít toto ošetřeno v composer.json a zároveň v kódu.