### PR TITLE
PHP ini for tester incl. required PHP extensions.

### DIFF
--- a/tests/php.ini
+++ b/tests/php.ini
@@ -1,4 +1,8 @@
 [PHP]
+extension=curl
+extension=dom
+extension=json
+extension=soap
 zend_extension=xdebug.so
 xdebug.remote_enable=on
 xdebug.remote_host=127.0.0.1


### PR DESCRIPTION
Just added php extensions into php.ini for Nette Tester. Without them it is not possible to run tests.