### PR TITLE
Type casting price value to float in price-formatting method.

### DIFF
--- a/src/Utils/Format.php
+++ b/src/Utils/Format.php
@@ -10,7 +10,7 @@ class Format
      */
     public static function price($value): string
     {
-        return number_format($value, 2, '.', '');
+        return number_format((float) $value, 2, '.', '');
     }
 
     public static function BKB(string $code): string


### PR DESCRIPTION
price() method now correctly accepts strings as parameter $value.

Else recieving error message: `"number_format() expects parameter 1 to be float, string given"`