### PR TITLE
fixing type error in SoapClient.pgp `($one_way) must be of type int, bool given`

### DIFF
--- a/src/SoapClient.php
+++ b/src/SoapClient.php
@@ -97,7 +97,7 @@ class SoapClient extends InternalSoapClient
         return $this->lastResponse;
     }
 
-    public function doRequestByCurl(string $request, string $location, string $action, int $version, int $one_way = 0): ?string
+    public function doRequestByCurl(string $request, string $location, string $action, int $version, int|bool $one_way = 0): ?string
     {
         $this->lastResponseHttpCode = null;
 


### PR DESCRIPTION
fixing error `FilipSedivy\EET\SoapClient::doRequestByCurl(): Argument #5 ($one_way) must be of type int, bool given, called in /var/www/html/vendor/filipsedivy/php-eet/src/SoapClient.php on line 93` by also allowing `$one_way` to be `bool`

this fixes the issue #59 